### PR TITLE
Update Alliance and Hero models to include all missing alliances and heroes

### DIFF
--- a/src/Model/Alliance.elm
+++ b/src/Model/Alliance.elm
@@ -2,13 +2,31 @@ module Model.Alliance exposing (Alliance(..), imagePath, toString)
 
 
 type Alliance
-    = Brawny
+    = Assassin
+    | Bloodbound
+    | Brawny
+    | Brute
+    | Champion
+    | Deadeye
+    | Demon
+    | Dragon
+    | Druid
+    | Healer
     | Heartless
+    | Human
+    | Hunter
+    | Insect
+    | Knight
+    | Mage
     | Primordial
     | Savage
     | Scaled
     | Spirit
+    | Summoner
     | Troll
+    | Vigilant
+    | Void
+    | Warlock
     | Warrior
 
 
@@ -20,11 +38,53 @@ imagePath name =
 toString : Alliance -> String
 toString name =
     case name of
+        Assassin ->
+            "assassin"
+
+        Bloodbound ->
+            "bloodbound"
+
         Brawny ->
             "brawny"
 
+        Brute ->
+            "brute"
+
+        Champion ->
+            "champion"
+
+        Deadeye ->
+            "deadeye"
+
+        Demon ->
+            "demon"
+
+        Dragon ->
+            "dragon"
+
+        Druid ->
+            "druid"
+
+        Healer ->
+            "healer"
+
         Heartless ->
             "heartless"
+
+        Human ->
+            "human"
+
+        Hunter ->
+            "hunter"
+
+        Insect ->
+            "insect"
+
+        Knight ->
+            "knight"
+
+        Mage ->
+            "mage"
 
         Primordial ->
             "primordial"
@@ -38,8 +98,20 @@ toString name =
         Spirit ->
             "spirit"
 
+        Summoner ->
+            "summoner"
+
         Troll ->
             "troll"
+
+        Vigilant ->
+            "vigilant"
+
+        Void ->
+            "void"
+
+        Warlock ->
+            "warlock"
 
         Warrior ->
             "warrior"

--- a/src/Model/Hero.elm
+++ b/src/Model/Hero.elm
@@ -12,54 +12,329 @@ import String.Extra
 
 
 type Hero
-    = EarthSpirit
+    = Abaddon
+    | ArcWarden
+    | Axe
+    | Batrider
+    | Beastmaster
+    | Bloodseeker
+    | Bristleback
+    | Broodmother
+    | ChaosKnight
+    | CrystalMaiden
+    | Dazzle
+    | Disruptor
+    | Doom
+    | DragonKnight
+    | DrowRanger
+    | EarthSpirit
+    | EmberSpirit
+    | Enigma
+    | FacelessVoid
+    | Io
     | Juggernaut
+    | KeeperoftheLight
+    | LegionCommander
+    | Lich
+    | Lifestealer
+    | LoneDruid
+    | Luna
+    | Lycan
+    | Magnus
+    | Medusa
+    | Mirana
+    | Morphling
+    | NaturesProphet
+    | Necrophos
+    | NyxAssassin
+    | OgreMagi
+    | Omniknight
     | Pudge
+    | QueenofPain
+    | Razor
+    | SandKing
+    | ShadowDemon
+    | ShadowFiend
+    | ShadowShaman
     | Slardar
+    | Slark
+    | Snapfire
+    | StormSpirit
+    | Sven
+    | TemplarAssassin
+    | Terrorblade
     | Tidehunter
     | Tiny
+    | TreantProtector
     | TrollWarlord
     | Tusk
+    | Venomancer
+    | Viper
+    | VoidSpirit
+    | WarlockHero -- to avoid naming collisions with Alliance
+    | Weaver
+    | Windranger
+    | WitchDoctor
 
 
 info : Hero -> HeroData
 info hero =
     case hero of
-        EarthSpirit ->
-            earthSpirit
+        Bloodseeker ->
+            bloodseeker
+
+        OgreMagi ->
+            ogreMagi
+
+        WarlockHero ->
+            warlock
+
+        Axe ->
+            axe
+
+        Beastmaster ->
+            beastmaster
+
+        Bristleback ->
+            bristleback
+
+        Disruptor ->
+            disruptor
 
         Juggernaut ->
             juggernaut
 
+        Snapfire ->
+            snapfire
+
+        ChaosKnight ->
+            chaosKnight
+
+        Doom ->
+            doom
+
+        QueenofPain ->
+            queenofPain
+
+        ShadowFiend ->
+            shadowFiend
+
+        Terrorblade ->
+            terrorblade
+
+        Viper ->
+            viper
+
+        NaturesProphet ->
+            naturesProphet
+
+        TreantProtector ->
+            treantProtector
+
+        Abaddon ->
+            abaddon
+
+        DrowRanger ->
+            drowRanger
+
+        Lich ->
+            lich
+
+        Lifestealer ->
+            lifestealer
+
+        Necrophos ->
+            necrophos
+
         Pudge ->
             pudge
 
-        Slardar ->
-            slardar
+        ShadowDemon ->
+            shadowDemon
 
-        Tidehunter ->
-            tidehunter
+        CrystalMaiden ->
+            crystalMaiden
+
+        DragonKnight ->
+            dragonKnight
+
+        KeeperoftheLight ->
+            keeperoftheLight
+
+        LegionCommander ->
+            legionCommander
+
+        Lycan ->
+            lycan
+
+        Omniknight ->
+            omniknight
+
+        Sven ->
+            sven
+
+        Broodmother ->
+            broodmother
+
+        NyxAssassin ->
+            nyxAssassin
+
+        Weaver ->
+            weaver
+
+        Luna ->
+            luna
+
+        ArcWarden ->
+            arcWarden
+
+        Io ->
+            io
+
+        Morphling ->
+            morphling
+
+        Razor ->
+            razor
 
         Tiny ->
             tiny
 
-        TrollWarlord ->
-            trollWarlord
+        LoneDruid ->
+            loneDruid
+
+        Magnus ->
+            magnus
+
+        SandKing ->
+            sandKing
 
         Tusk ->
             tusk
 
+        Medusa ->
+            medusa
+
+        Slardar ->
+            slardar
+
+        Slark ->
+            slark
+
+        Tidehunter ->
+            tidehunter
+
+        Venomancer ->
+            venomancer
+
+        EarthSpirit ->
+            earthSpirit
+
+        EmberSpirit ->
+            emberSpirit
+
+        StormSpirit ->
+            stormSpirit
+
+        Batrider ->
+            batrider
+
+        Dazzle ->
+            dazzle
+
+        ShadowShaman ->
+            shadowShaman
+
+        TrollWarlord ->
+            trollWarlord
+
+        WitchDoctor ->
+            witchDoctor
+
+        Mirana ->
+            mirana
+
+        TemplarAssassin ->
+            templarAssassin
+
+        Windranger ->
+            windranger
+
+        Enigma ->
+            enigma
+
+        FacelessVoid ->
+            facelessVoid
+
+        VoidSpirit ->
+            voidSpirit
+
 
 allHeroes : List HeroData
 allHeroes =
-    [ earthSpirit
+    [ abaddon
+    , arcWarden
+    , axe
+    , batrider
+    , beastmaster
+    , bloodseeker
+    , bristleback
+    , broodmother
+    , chaosKnight
+    , crystalMaiden
+    , dazzle
+    , disruptor
+    , doom
+    , dragonKnight
+    , drowRanger
+    , earthSpirit
+    , emberSpirit
+    , enigma
+    , facelessVoid
+    , io
     , juggernaut
+    , keeperoftheLight
+    , legionCommander
+    , lich
+    , lifestealer
+    , loneDruid
+    , luna
+    , lycan
+    , magnus
+    , medusa
+    , mirana
+    , morphling
+    , naturesProphet
+    , necrophos
+    , nyxAssassin
+    , ogreMagi
+    , omniknight
     , pudge
+    , queenofPain
+    , razor
+    , sandKing
+    , shadowDemon
+    , shadowFiend
+    , shadowShaman
     , slardar
+    , slark
+    , snapfire
+    , stormSpirit
+    , sven
+    , templarAssassin
+    , terrorblade
     , tidehunter
     , tiny
+    , treantProtector
     , trollWarlord
     , tusk
+    , venomancer
+    , viper
+    , voidSpirit
+    , warlock
+    , weaver
+    , windranger
+    , witchDoctor
     ]
 
 
@@ -77,9 +352,79 @@ type alias HeroData =
     }
 
 
-tusk : HeroData
-tusk =
-    HeroData Tusk [ Warrior, Savage ]
+abaddon : HeroData
+abaddon =
+    HeroData Abaddon [ Heartless, Knight ]
+
+
+arcWarden : HeroData
+arcWarden =
+    HeroData ArcWarden [ Primordial, Summoner ]
+
+
+axe : HeroData
+axe =
+    HeroData Axe [ Brawny, Brute ]
+
+
+batrider : HeroData
+batrider =
+    HeroData Batrider [ Troll, Knight ]
+
+
+beastmaster : HeroData
+beastmaster =
+    HeroData Beastmaster [ Brawny, Hunter ]
+
+
+bloodseeker : HeroData
+bloodseeker =
+    HeroData Bloodseeker [ Bloodbound, Deadeye ]
+
+
+bristleback : HeroData
+bristleback =
+    HeroData Bristleback [ Brawny, Savage ]
+
+
+broodmother : HeroData
+broodmother =
+    HeroData Broodmother [ Insect, Warlock ]
+
+
+chaosKnight : HeroData
+chaosKnight =
+    HeroData ChaosKnight [ Demon, Knight ]
+
+
+crystalMaiden : HeroData
+crystalMaiden =
+    HeroData CrystalMaiden [ Human, Mage ]
+
+
+dazzle : HeroData
+dazzle =
+    HeroData Dazzle [ Troll, Healer ]
+
+
+disruptor : HeroData
+disruptor =
+    HeroData Disruptor [ Brawny, Warlock ]
+
+
+doom : HeroData
+doom =
+    HeroData Doom [ Demon, Brute ]
+
+
+dragonKnight : HeroData
+dragonKnight =
+    HeroData DragonKnight [ Human, Dragon, Knight ]
+
+
+drowRanger : HeroData
+drowRanger =
+    HeroData DrowRanger [ Heartless, Vigilant, Hunter ]
 
 
 earthSpirit : HeroData
@@ -87,9 +432,109 @@ earthSpirit =
     HeroData EarthSpirit [ Spirit, Warrior ]
 
 
+emberSpirit : HeroData
+emberSpirit =
+    HeroData EmberSpirit [ Spirit, Assassin ]
+
+
+enigma : HeroData
+enigma =
+    HeroData Enigma [ Void, Primordial ]
+
+
+facelessVoid : HeroData
+facelessVoid =
+    HeroData FacelessVoid [ Void, Assassin ]
+
+
+io : HeroData
+io =
+    HeroData Io [ Primordial, Druid ]
+
+
 juggernaut : HeroData
 juggernaut =
     HeroData Juggernaut [ Brawny, Warrior ]
+
+
+keeperoftheLight : HeroData
+keeperoftheLight =
+    HeroData KeeperoftheLight [ Human, Mage ]
+
+
+legionCommander : HeroData
+legionCommander =
+    HeroData LegionCommander [ Human, Champion ]
+
+
+lich : HeroData
+lich =
+    HeroData Lich [ Heartless, Mage ]
+
+
+lifestealer : HeroData
+lifestealer =
+    HeroData Lifestealer [ Heartless, Brute ]
+
+
+loneDruid : HeroData
+loneDruid =
+    HeroData LoneDruid [ Savage, Druid, Summoner ]
+
+
+luna : HeroData
+luna =
+    HeroData Luna [ Knight, Vigilant ]
+
+
+lycan : HeroData
+lycan =
+    HeroData Lycan [ Human, Savage, Summoner ]
+
+
+magnus : HeroData
+magnus =
+    HeroData Magnus [ Savage, Druid ]
+
+
+medusa : HeroData
+medusa =
+    HeroData Medusa [ Scaled, Hunter ]
+
+
+mirana : HeroData
+mirana =
+    HeroData Mirana [ Vigilant, Hunter ]
+
+
+morphling : HeroData
+morphling =
+    HeroData Morphling [ Primordial, Mage ]
+
+
+naturesProphet : HeroData
+naturesProphet =
+    HeroData NaturesProphet [ Druid, Summoner ]
+
+
+necrophos : HeroData
+necrophos =
+    HeroData Necrophos [ Heartless, Warlock, Healer ]
+
+
+nyxAssassin : HeroData
+nyxAssassin =
+    HeroData NyxAssassin [ Insect, Assassin ]
+
+
+ogreMagi : HeroData
+ogreMagi =
+    HeroData OgreMagi [ Bloodbound, Brute, Mage ]
+
+
+omniknight : HeroData
+omniknight =
+    HeroData Omniknight [ Human, Knight, Healer ]
 
 
 pudge : HeroData
@@ -97,9 +542,69 @@ pudge =
     HeroData Pudge [ Heartless, Warrior ]
 
 
+queenofPain : HeroData
+queenofPain =
+    HeroData QueenofPain [ Demon, Assassin ]
+
+
+razor : HeroData
+razor =
+    HeroData Razor [ Primordial, Mage ]
+
+
+sandKing : HeroData
+sandKing =
+    HeroData SandKing [ Savage, Insect ]
+
+
+shadowDemon : HeroData
+shadowDemon =
+    HeroData ShadowDemon [ Heartless, Demon ]
+
+
+shadowFiend : HeroData
+shadowFiend =
+    HeroData ShadowFiend [ Demon, Warlock ]
+
+
+shadowShaman : HeroData
+shadowShaman =
+    HeroData ShadowShaman [ Troll, Summoner ]
+
+
 slardar : HeroData
 slardar =
     HeroData Slardar [ Scaled, Warrior ]
+
+
+slark : HeroData
+slark =
+    HeroData Slark [ Scaled, Assassin ]
+
+
+snapfire : HeroData
+snapfire =
+    HeroData Snapfire [ Brawny, Dragon ]
+
+
+stormSpirit : HeroData
+stormSpirit =
+    HeroData StormSpirit [ Spirit, Mage ]
+
+
+sven : HeroData
+sven =
+    HeroData Sven [ Human, Scaled, Knight ]
+
+
+templarAssassin : HeroData
+templarAssassin =
+    HeroData TemplarAssassin [ Vigilant, Void, Assassin ]
+
+
+terrorblade : HeroData
+terrorblade =
+    HeroData Terrorblade [ Demon, Hunter ]
 
 
 tidehunter : HeroData
@@ -112,37 +617,247 @@ tiny =
     HeroData Tiny [ Primordial, Warrior ]
 
 
+treantProtector : HeroData
+treantProtector =
+    HeroData TreantProtector [ Druid, Brute ]
+
+
 trollWarlord : HeroData
 trollWarlord =
     HeroData TrollWarlord [ Troll, Warrior ]
 
 
+tusk : HeroData
+tusk =
+    HeroData Tusk [ Savage, Warrior ]
+
+
+venomancer : HeroData
+venomancer =
+    HeroData Venomancer [ Scaled, Summoner ]
+
+
+viper : HeroData
+viper =
+    HeroData Viper [ Dragon, Assassin ]
+
+
+voidSpirit : HeroData
+voidSpirit =
+    HeroData VoidSpirit [ Void, Spirit ]
+
+
+warlock : HeroData
+warlock =
+    HeroData WarlockHero [ Bloodbound, Warlock, Healer ]
+
+
+weaver : HeroData
+weaver =
+    HeroData Weaver [ Insect, Hunter ]
+
+
+windranger : HeroData
+windranger =
+    HeroData Windranger [ Vigilant, Hunter ]
+
+
+witchDoctor : HeroData
+witchDoctor =
+    HeroData WitchDoctor [ Troll, Warlock ]
+
+
 toString : Hero -> String
 toString name =
     case name of
-        EarthSpirit ->
-            "Earth Spirit"
+        Bloodseeker ->
+            "Bloodseeker"
+
+        OgreMagi ->
+            "Ogre Magi"
+
+        WarlockHero ->
+            "Warlock"
+
+        Axe ->
+            "Axe"
+
+        Beastmaster ->
+            "Beastmaster"
+
+        Bristleback ->
+            "Bristleback"
+
+        Disruptor ->
+            "Disruptor"
 
         Juggernaut ->
             "Juggernaut"
 
+        Snapfire ->
+            "Snapfire"
+
+        ChaosKnight ->
+            "Chaos Knight"
+
+        Doom ->
+            "Doom"
+
+        QueenofPain ->
+            "Queen of Pain"
+
+        ShadowFiend ->
+            "Shadow Fiend"
+
+        Terrorblade ->
+            "Terrorblade"
+
+        Viper ->
+            "Viper"
+
+        NaturesProphet ->
+            "Nature's Prophet"
+
+        TreantProtector ->
+            "Treant Protector"
+
+        Abaddon ->
+            "Abaddon"
+
+        DrowRanger ->
+            "Drow Ranger"
+
+        Lich ->
+            "Lich"
+
+        Lifestealer ->
+            "Lifestealer"
+
+        Necrophos ->
+            "Necrophos"
+
         Pudge ->
             "Pudge"
 
-        Slardar ->
-            "Slardar"
+        ShadowDemon ->
+            "Shadow Demon"
 
-        Tidehunter ->
-            "Tidehunter"
+        CrystalMaiden ->
+            "Crystal Maiden"
+
+        DragonKnight ->
+            "Dragon Knight"
+
+        KeeperoftheLight ->
+            "Keeper of the Light"
+
+        LegionCommander ->
+            "Legion Commander"
+
+        Lycan ->
+            "Lycan"
+
+        Omniknight ->
+            "Omniknight"
+
+        Sven ->
+            "Sven"
+
+        Broodmother ->
+            "Broodmother"
+
+        NyxAssassin ->
+            "Nyx Assassin"
+
+        Weaver ->
+            "Weaver"
+
+        Luna ->
+            "Luna"
+
+        ArcWarden ->
+            "Arc Warden"
+
+        Io ->
+            "Io"
+
+        Morphling ->
+            "Morphling"
+
+        Razor ->
+            "Razor"
 
         Tiny ->
             "Tiny"
 
-        TrollWarlord ->
-            "Troll Warlord"
+        LoneDruid ->
+            "Lone Druid"
+
+        Magnus ->
+            "Magnus"
+
+        SandKing ->
+            "Sand King"
 
         Tusk ->
             "Tusk"
+
+        Medusa ->
+            "Medusa"
+
+        Slardar ->
+            "Slardar"
+
+        Slark ->
+            "Slark"
+
+        Tidehunter ->
+            "Tidehunter"
+
+        Venomancer ->
+            "Venomancer"
+
+        EarthSpirit ->
+            "Earth Spirit"
+
+        EmberSpirit ->
+            "Ember Spirit"
+
+        StormSpirit ->
+            "Storm Spirit"
+
+        Batrider ->
+            "Batrider"
+
+        Dazzle ->
+            "Dazzle"
+
+        ShadowShaman ->
+            "Shadow Shaman"
+
+        TrollWarlord ->
+            "Troll Warlord"
+
+        WitchDoctor ->
+            "Witch Doctor"
+
+        Mirana ->
+            "Mirana"
+
+        TemplarAssassin ->
+            "Templar Assassin"
+
+        Windranger ->
+            "Windranger"
+
+        Enigma ->
+            "Enigma"
+
+        FacelessVoid ->
+            "Faceless Void"
+
+        VoidSpirit ->
+            "Void Spirit"
 
 
 imagePath : Hero -> String

--- a/src/View/Counter.elm
+++ b/src/View/Counter.elm
@@ -45,7 +45,9 @@ import Model.Alliance exposing (Alliance(..))
 
 
 type Shape
-    = OneByThree
+    = OneByOne
+    | OneByTwo
+    | OneByThree
     | ThreeByTwo
     | TwoByThree
     | TwoByTwo
@@ -79,11 +81,67 @@ Scaled
 counter : Alliance -> Int -> Counter
 counter alliance =
     case alliance of
+        Assassin ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByThree }
+
+        Bloodbound ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = OneByTwo }
+
         Brawny ->
             Counter { color = "red", shape = TwoByTwo }
 
+        Brute ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByTwo }
+
+        Champion ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = OneByOne }
+
+        Deadeye ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = OneByOne }
+
+        Demon ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = OneByOne }
+
+        Dragon ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = OneByTwo }
+
+        Druid ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByTwo }
+
+        Healer ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByTwo }
+
         Heartless ->
             Counter { color = "grey", shape = ThreeByTwo }
+
+        Human ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = ThreeByTwo }
+
+        Hunter ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByThree }
+
+        Insect ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByThree }
+
+        Knight ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByThree }
+
+        Mage ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByThree }
 
         Primordial ->
             Counter { color = "light blue", shape = ThreeByTwo }
@@ -97,8 +155,24 @@ counter alliance =
         Spirit ->
             Counter { color = "grey", shape = OneByThree }
 
+        Summoner ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByTwo }
+
         Troll ->
             Counter { color = "brown", shape = TwoByTwo }
+
+        Vigilant ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = TwoByTwo }
+
+        Void ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = OneByThree }
+
+        Warlock ->
+            -- TODO pick unique color
+            Counter { color = "black", shape = ThreeByTwo }
 
         Warrior ->
             Counter { color = "blue", shape = TwoByThree }
@@ -107,6 +181,21 @@ counter alliance =
 toHtml : Counter -> Html msg
 toHtml (Counter { shape } count) =
     case shape of
+        OneByOne ->
+            div [ class "counter" ]
+                [ div [ class "tier" ]
+                    [ bubble (count >= 1)
+                    ]
+                ]
+
+        OneByTwo ->
+            div [ class "counter" ]
+                [ div [ class "tier" ]
+                    [ bubble (count >= 1)
+                    , bubble (count >= 2)
+                    ]
+                ]
+
         OneByThree ->
             div [ class "counter" ]
                 [ div [ class "tier" ]

--- a/tests/CrewTest.elm
+++ b/tests/CrewTest.elm
@@ -29,5 +29,8 @@ crewTest =
             \() ->
                 [ Slardar, Tidehunter ]
                     |> Model.Crew.suggest
-                    |> Expect.equal (Just Tusk)
+                    |> Expect.all
+                        [ Expect.notEqual (Just Slardar)
+                        , Expect.notEqual (Just Tidehunter)
+                        ]
         ]


### PR DESCRIPTION
Shoutout to Google Sheets - I used https://docs.google.com/spreadsheets/d/1aXkPxTQqHrmQbBJOsK6BrJqLf6nXFHd1MjFFcoaV3vQ/edit?usp=sharing to help generate code for a lot of the mechanical parts. Be warned, that sheet isn't perfect, I had to hand-fix some stuff upon copying into code (eg. renaming the hero Warlock to WarlockHero).

I left TODOs in Counter.elm to pick colors for all the new alliances.

At some point in the future we should consider a strategy where we get this information from a more standard data format, perhaps even from Steam itself somehow. This would at least cut down on the mechanical pain of translating all this information to elm code, but would solve a larger issue: the next Underlords patch that updates alliance information will currently require a code change for this repo to stay up to date